### PR TITLE
feat(auth): add register/login with JWT authentication

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,88 @@
+from fastapi import APIRouter, Depends, HTTPException, Header
+from sqlalchemy.orm import Session
+from passlib.context import CryptContext
+from jose import jwt, JWTError, ExpiredSignatureError
+from datetime import datetime, timedelta
+from app import models, schemas
+from app.db import SessionLocal
+
+router = APIRouter()
+
+SECRET_KEY = "super-secret-key"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+def hash_password(password: str):
+    return pwd_context.hash(password)
+
+def verify_password(plain, hashed):
+    return pwd_context.verify(plain, hashed)
+
+def create_token(data: dict):
+    expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    data.update({"exp": expire})
+    return jwt.encode(data, SECRET_KEY, algorithm=ALGORITHM)
+
+def get_current_user(
+    authorization: str = Header(..., description="Format: Bearer <token>"),
+    db: Session = Depends(get_db),
+):
+    # 1) 檢查格式是否為 Bearer
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+
+    token = parts[1]
+
+    try:
+        # 2) 解碼 + 自動驗證 exp
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        sub = payload.get("sub")
+        if sub is None:
+            raise HTTPException(status_code=401, detail="Invalid token payload")
+
+        # 有些人把 sub 存成字串，這裡保險一點做轉型
+        try:
+            user_id = int(sub)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=401, detail="Invalid token subject")
+
+        # 3) 查 DB
+        user = db.query(models.User).filter(models.User.id == user_id).first()
+        if not user:
+            raise HTTPException(status_code=401, detail="User not found")
+
+        return user
+
+    except ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+@router.post("/register", response_model=schemas.UserRead)
+def register(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    if db.query(models.User).filter_by(username=user.username).first():
+        raise HTTPException(status_code=400, detail="Username already taken")
+    hashed = hash_password(user.password)
+    new_user = models.User(username=user.username, password_hash=hashed)
+    db.add(new_user)
+    db.commit()
+    db.refresh(new_user)
+    return new_user
+
+@router.post("/login")
+def login(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    db_user = db.query(models.User).filter_by(username=user.username).first()
+    if not db_user or not verify_password(user.password, db_user.password_hash):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = create_token({"sub": db_user.id})
+    return {"access_token": token, "token_type": "bearer"}

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,13 @@
 from fastapi import FastAPI
 from app.db import Base, engine
+from app.auth import router as auth_router
 
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="Task Manager API")
+
+app.include_router(auth_router, prefix="/auth", tags=["auth"])
+
 
 @app.get("/health")
 def health_check():

--- a/app/models.py
+++ b/app/models.py
@@ -6,10 +6,12 @@ class User(Base):
     __tablename__ = "users"
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String, unique=True, index=True, nullable=False)
-    password_hash = Column(String, back_populates="owner")
+    password_hash = Column(String, nullable=False)
+
+    tasks = relationship("Task", back_populates="owner")
 
 class Task(Base):
-    __tabelname__ = "tasks"
+    __tablename__ = "tasks"
     id = Column(Integer, primary_key=True, index=True)
     title = Column(Integer, nullable=False)
     completed = Column(Boolean, default=False)


### PR DESCRIPTION
## Summary
- 修正 ORM 對應錯誤：
  - 將 __tabelname__ 拼字錯誤修正為 __tablename__
  - 移除 Column 上誤用的 back_populates，改為正確寫在 relationship(back_populates=...)
- 確保 User 與 Task 之間的雙向關聯可正確建立
- 新增使用者模型與相關 Schema（UserCreate, UserRead）
- 新增 /auth/register API：使用 bcrypt 雜湊儲存密碼
- 新增 /auth/login API：驗證帳密，成功後回傳 JWT Token
- 新增 JWT 驗證流程（get_current_user）
- 將 auth router 加入 main.py

## Test
- POST `/auth/register` 建立新帳號
- POST `/auth/login` 取得 JWT token
- 使用 JWT token 呼叫受保護的 API（例如 /tasks 後續會用到）
- 錯誤帳號或密碼應回傳 401

## Notes
- 這是後端最小可用驗證流程
- 下一步計劃新增 `feature/tasks-crud`